### PR TITLE
Run babel before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "npm run build && npm run build-test && ./node_modules/.bin/mocha --recursive test/lib",
     "coverage": "./node_modules/.bin/eslint src/** && npm run build && npm run build-test && ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive test/lib",
     "upload-coverage": "./node_modules/.bin/codecov --root=lib",
-    "postinstall": "npm run build"
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run test"
   },
   "repository": {
     "type": "git",
@@ -29,15 +30,15 @@
   },
   "homepage": "https://github.com/TestArmada/magellan-local-executor#readme",
   "dependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-eslint": "^7.1.1",
-    "babel-preset-es2015": "^6.18.0",
     "cli-color": "^1.1.0",
     "lodash": "^4.17.4",
     "testarmada-logger": "^1.1.1",
     "yargs": "^6.6.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-eslint": "^7.2.3",
+    "babel-preset-es2015": "^6.24.1",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "codecov": "^1.0.1",


### PR DESCRIPTION
While trying to upgrade babel to v7 I'm having issues with this package because when it uses `babel` on `postinstall` that ends up using the v6 dependencies with `@babel/cli` v7, which has already been installed, and ends up throwing an error.
The error is discussed on this babel issue (even though with a different context): https://github.com/babel/babel/issues/8482

This PR makes babel run on the `prepare` npm hook, and has the behavior recommended by npm: https://docs.npmjs.com/misc/scripts#prepublish-and-prepare
I also added `npm run test` on `prepublishOnly`, to make sure tests are running before the package is published.

This change is similar to what has been done to testarmada-logger on https://github.com/TestArmada/testarmada-logger/commit/72f0d77408f3e1df83bcec47b4a5e2f6b49620c7 by @archlichking 